### PR TITLE
Create synchronator.service

### DIFF
--- a/scripts/systemd/system/synchronator.service
+++ b/scripts/systemd/system/synchronator.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Synchronator Volume Control Service
+
+[Service]
+PIDFile=/var/run/synchronator/synchronator.pid
+ExecStartPre=/usr/bin/mkdir -p /var/run/synchronator
+ExecStart=/usr/local/bin/synchronator
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I created a unit file, so synchronator can be installed as a service on distros that use systemd as service manager.

On Arch Linux for example the script needs to be put in /etc/systemd/system/. Run systemctl daemon-reload to scan for new units and systemctl enable synchronator to enable it on bootup.
